### PR TITLE
Switch to the new Fink API URL

### DIFF
--- a/src/anomaly/TNS/submit.py
+++ b/src/anomaly/TNS/submit.py
@@ -58,7 +58,7 @@ def tns_transfer(
     report = {"at_report": {}}
     for index, obj in enumerate(objects):
         r = requests.post(
-            'https://fink-portal.org/api/v1/objects',
+            'https://api.fink-portal.org/api/v1/objects',
             json={
             'objectId': obj,
             'withupperlim': 'True'

--- a/src/anomaly/TNS/utils.py
+++ b/src/anomaly/TNS/utils.py
@@ -255,7 +255,7 @@ def print_fink_statistics(tns_logs_folder=None, tns_catalog=None):
     else:
         # Get latests 5 Early SN Ia candidates
         r = requests.post(
-          "https://fink-portal.org/api/v1/latests",
+          "https://api.fink-portal.org/api/v1/latests",
           json={
             "class": "Early SN Ia candidate",
             "columns": "i:objectId",

--- a/src/anomaly/submit.py
+++ b/src/anomaly/submit.py
@@ -57,7 +57,7 @@ def tns_transfer(
     report = {"at_report": {}}
     for index, obj in enumerate(objects):
         r = requests.post(
-            'https://fink-portal.org/api/v1/objects',
+            'https://api.fink-portal.org/api/v1/objects',
             json={
             'objectId': obj,
             'withupperlim': 'True'


### PR DESCRIPTION
Hello,

As part of the transition to a new system for Rubin, the URL to access the Fink API has changed:
- old: https://fink-portal.org/api/v1/<endpoint\>
- new: https://api.fink-portal.org/api/v1/<endpoint\>

In this transition period, in case of trouble do not hesitate to check https://fink-broker.readthedocs.io/en/latest/migration