### PR TITLE
Avoid tracebacks on HTTP 401.

### DIFF
--- a/src/anomaly/auth/jwt_handler.py
+++ b/src/anomaly/auth/jwt_handler.py
@@ -59,11 +59,15 @@ async def cookie_decode_token(token: str) -> User:
     )
 
     try:
-        token = token.removeprefix("Bearer").strip()
-        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
-        username: str = payload.get("user")
+        username = None
+        if token is not None:
+            token = token.removeprefix("Bearer").strip()
+            payload = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
+            username: str = payload.get("user")
+
         if username is None:
             raise credentials_exception
+
     except JWTError as e:
         raise credentials_exception
     

--- a/src/anomaly/main.py
+++ b/src/anomaly/main.py
@@ -275,6 +275,9 @@ async def index(request: Request):
             im_ids.append(buf)
         im_ids = im_ids[::-1]
 
+    except HTTPException:
+        pass
+
     except Exception as e:
         import traceback
         logger.info('Serving / failed: %s' % traceback.format_exc())


### PR DESCRIPTION
Service annoys with a traceback on every request wwithout a cookie. And there are quite a few such requests.
This patch disables traceback output for HTTP Exceptions (which include all http codes and are not really an exception)